### PR TITLE
Implement `#find_or_create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,30 @@ Or install it yourself as:
 
 ## Usage
 
-### Pinging to authenticate
+### Ping to authenticate
 
 Verify that your API key is valid and that you can reach the Geckoboard API.
 
 ```ruby
 client = Geckoboard.client('222efc82e7933138077b1c2554439e15')
-client.ping
+client.ping # => true
+```
+
+### Find or create
+
+Verify an existing dataset or create a new one.
+
+```ruby
+dataset = client.datasets.find_or_create('sales.gross', fields: {
+  amount: {
+    type: :number,
+    name: 'Amount',
+  },
+  timestamp: {
+    type: :datetime,
+    name: 'Time'
+  }
+})
 ```
 
 ## Development

--- a/lib/geckoboard.rb
+++ b/lib/geckoboard.rb
@@ -1,11 +1,17 @@
 require 'net/http'
 require 'json'
+require 'cgi'
 
 require 'geckoboard/version'
+require 'geckoboard/connection'
 require 'geckoboard/client'
+require 'geckoboard/datasets'
+require 'geckoboard/dataset'
 require 'geckoboard/errors'
 
 module Geckoboard
+  USER_AGENT = "Geckoboard-Ruby/#{VERSION}"
+
   def self.client(api_key)
     Client.new(api_key)
   end

--- a/lib/geckoboard/client.rb
+++ b/lib/geckoboard/client.rb
@@ -1,48 +1,18 @@
 module Geckoboard
   class Client
-    USER_AGENT = "Geckoboard-Ruby/#{VERSION}"
-
-    attr_reader :api_key
+    attr_reader :connection
 
     def initialize(api_key)
-      @api_key = api_key
+      @connection = Connection.new(api_key)
     end
 
     def ping
-      http = Net::HTTP.new('api.geckoboard.com', 443)
-      http.use_ssl = true
-
-      request = Net::HTTP::Get.new('/')
-      request.basic_auth(api_key, '')
-      request['User-Agent'] = USER_AGENT
-
-      response = http.request(request)
-
-      case response
-      when Net::HTTPOK
-        true
-      when Net::HTTPUnauthorized
-        raise UnauthorizedError, extract_error_message(response)
-      else
-        error_message = extract_error_message(response) ||
-          "Server responded with unexpected status code (#{response.code})"
-
-        raise UnexpectedStatusError, error_message
-      end
+      connection.get('/')
+      true
     end
 
-    private
-
-    def extract_error_message(response)
-      return unless response_is_json? response
-
-      JSON.parse(response.body)
-        .fetch('error', {})
-        .fetch('message', nil)
-    end
-
-    def response_is_json?(response)
-      response['Content-Type'] == 'application/json'
+    def datasets
+      Datasets.new(connection)
     end
   end
 end

--- a/lib/geckoboard/connection.rb
+++ b/lib/geckoboard/connection.rb
@@ -1,0 +1,68 @@
+module Geckoboard
+  class Connection
+    attr_reader :api_key
+
+    def initialize(api_key)
+      @api_key = api_key
+    end
+
+    def get(path)
+      request = Net::HTTP::Get.new(path)
+
+      make_request(request)
+    end
+
+    def put(path, body)
+      request = Net::HTTP::Put.new(path)
+      request['Content-Type'] = 'application/json'
+      request.body = body
+
+      make_request(request)
+    end
+
+    private
+
+    def make_request(request)
+      request.basic_auth(api_key, '')
+      request['User-Agent'] = USER_AGENT
+
+      response = http.request(request)
+      check_for_errors(response)
+      response
+    end
+
+    def check_for_errors(response)
+      return if response.code.to_i < 400
+
+      error_message = extract_error_message(response) ||
+        "Server responded with unexpected status code (#{response.code})"
+
+      exception = case response
+                  when Net::HTTPUnauthorized then UnauthorizedError
+                  when Net::HTTPConflict     then ConflictError
+                  when Net::HTTPBadRequest   then BadRequestError
+                  else UnexpectedStatusError
+                  end
+
+      raise exception, error_message
+    end
+
+    def extract_error_message(response)
+      return unless response_is_json? response
+
+      JSON.parse(response.body)
+        .fetch('error', {})
+        .fetch('message', nil)
+    end
+
+    def response_is_json?(response)
+      (response['Content-Type'] || '').split(';').first == 'application/json'
+    end
+
+    def http
+      http = Net::HTTP.new('api.geckoboard.com', 443)
+      http.use_ssl = true
+      http
+    end
+  end
+end

--- a/lib/geckoboard/dataset.rb
+++ b/lib/geckoboard/dataset.rb
@@ -1,0 +1,9 @@
+module Geckoboard
+  class Dataset
+    attr_reader :id
+
+    def initialize(id)
+      @id = id
+    end
+  end
+end

--- a/lib/geckoboard/datasets.rb
+++ b/lib/geckoboard/datasets.rb
@@ -1,0 +1,21 @@
+module Geckoboard
+  class Datasets
+    attr_reader :connection
+
+    def initialize(connection)
+      @connection = connection
+    end
+
+    def find_or_create(dataset_id, fields: fields)
+      path = dataset_path(dataset_id)
+      response = connection.put(path, { fields: fields }.to_json)
+      Dataset.new(JSON.parse(response.body).fetch('id'))
+    end
+
+    private
+
+    def dataset_path(dataset_id)
+      "/datasets/#{CGI.escape(dataset_id)}"
+    end
+  end
+end

--- a/lib/geckoboard/errors.rb
+++ b/lib/geckoboard/errors.rb
@@ -1,5 +1,7 @@
 module Geckoboard
   BaseError             = Class.new(StandardError)
+  BadRequestError       = Class.new(BaseError)
+  ConflictError         = Class.new(BaseError)
   UnauthorizedError     = Class.new(BaseError)
   UnexpectedStatusError = Class.new(BaseError)
 end


### PR DESCRIPTION
This PR introduces the `#find_or_create` method for datasets, it also extracts a `Connection` object for handling the low-level HTTP interactions including authentication and error handling.

**Example:**

``` ruby
client.datasets.find_or_create('sales.gross', fields: {
  amount: {
    type: :number,
    name: 'Amount',
  },
  timestamp: {
    type: :datetime,
    name: 'Time'
  }
})
```
