### PR TITLE
Adding #post method for new Widget class

### DIFF
--- a/geckoboard-ruby.gemspec
+++ b/geckoboard-ruby.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'webmock', '~> 2.1'
+  spec.add_runtime.dependency 'rest-client', '~> 2.0.0'
 end

--- a/geckoboard-ruby.gemspec
+++ b/geckoboard-ruby.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'webmock', '~> 2.1'
-  spec.add_runtime.dependency 'rest-client', '~> 2.0.0'
+  spec.add_runtime_dependency 'rest-client', '~> 2.0.0'
 end

--- a/lib/geckoboard/widget.rb
+++ b/lib/geckoboard/widget.rb
@@ -1,0 +1,16 @@
+module Geckoboard
+  class Widget
+    attr_reader :widget_key
+
+    def initialize(widget_key)
+      @widget_key = widget_key
+    end
+
+    def post(data)
+      RestClient.post("https://push.geckoboard.com/v1/send/#{widget_key}", {
+          api_key: ENV['GECKOBOARD_KEY'],
+          data: data
+        }.to_json, content_type: :json, accept: :json)
+    end
+  end
+end


### PR DESCRIPTION
@BRMatt - Created a method to post data to widgets, and figured opening a PR to add to the core `geckoboard-ruby` gem wouldn't hurt.

* Added runtime dependency for `rest-client`
* Added `Widget` class with `#post` method

Any and all feedback welcome!