### PR TITLE
Add duration field type, support optional strings, and tell git to ignore DS_Store and vscode files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+.DS_Store
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -42,20 +42,25 @@ Verify an existing dataset or create a new one.
 
 ```ruby
 dataset = client.datasets.find_or_create('sales.gross', fields: [
+  Geckoboard::NumberField.new(:amount, name: 'Amount', optional: true),
   Geckoboard::MoneyField.new(:cost, name: 'Cost', currency_code: 'USD'),
-  Geckoboard::DateTimeField.new(:timestamp, name: 'Time'),
-  Geckoboard::NumberField.new(:amount, name: 'Amount', optional: true)
+  Geckoboard::DurationField.new(:span, name: 'Span', time_unit: 'seconds', optional: true),
+  Geckoboard::DateTimeField.new(:timestamp, name: 'Time'),          
+  Geckoboard::PercentageField.new(:completion, name: 'Completion'),
+  Geckoboard::StringField.new(:company, name: 'Company')
 ], unique_by: [:timestamp])
 ```
 
 Available field types:
 
+- `NumberField`
+- `MoneyField`
+- `DurationField`
 - `DateField`
 - `DateTimeField`
-- `NumberField`
 - `PercentageField`
 - `StringField`
-- `MoneyField`
+
 
 `unique_by` is an optional array of one or more field names whose values will be unique across all your records.
 

--- a/lib/geckoboard/field_types.rb
+++ b/lib/geckoboard/field_types.rb
@@ -28,7 +28,7 @@ module Geckoboard
     end
   end
 
-  class StringField < Field
+  class StringField < OptionalField
     def to_hash
       super.merge(type: :string)
     end
@@ -64,6 +64,21 @@ module Geckoboard
 
     def to_hash
       super.merge(type: :money, currency_code: currency_code)
+    end
+  end
+
+  class DurationField < OptionalField
+    attr_reader :time_unit
+
+    def initialize(id, time_unit: nil, **options)
+      raise ArgumentError, "`time_unit:' is a required argument" if time_unit.nil?
+
+      super(id, **options)
+      @time_unit = time_unit
+    end
+
+    def to_hash
+      super.merge(type: :duration, time_unit: time_unit)
     end
   end
 

--- a/spec/geckoboard/client_spec.rb
+++ b/spec/geckoboard/client_spec.rb
@@ -128,6 +128,22 @@ module Geckoboard
                 optional: false,
                 type: :money,
                 currency_code: 'USD',
+              },
+              span: {
+                name: 'Span'
+                optional: false,
+                type: :duration,
+                time_unit: 'seconds',
+              },
+              completion: {
+                name: 'Completion'
+                optional: false,
+                type: :percentage,
+              },
+              company: {
+                name: 'Company'
+                optional: false,
+                type: :string,
               }
             }
           end
@@ -151,7 +167,10 @@ module Geckoboard
             subject.datasets.find_or_create('sales.gross', fields: [
               Geckoboard::NumberField.new(:amount, name: 'Amount'),
               Geckoboard::DateTimeField.new(:timestamp, name: 'Time'),
-              Geckoboard::MoneyField.new(:cost, name: 'Cost', currency_code: 'USD')
+              Geckoboard::MoneyField.new(:cost, name: 'Cost', currency_code: 'USD'),
+              Geckoboard::DurationField.new(:span, name: 'Span', time_unit: 'seconds'),
+              Geckoboard::PercentageField.new(:completion, name: 'Completion'),
+              Geckoboard::StringField.new(:company, name: 'Company')
             ])
           end
         end
@@ -207,6 +226,11 @@ module Geckoboard
                 name: 'Completion',
                 optional: true,
                 type: :percentage,
+              },
+              company: {
+                name: 'Company',
+                optional: true,
+                type: :string,
               }
             }
           end
@@ -231,7 +255,9 @@ module Geckoboard
               Geckoboard::NumberField.new(:amount, name: 'Amount', optional: true),
               Geckoboard::DateTimeField.new(:timestamp, name: 'Time'),
               Geckoboard::MoneyField.new(:cost, name: 'Cost', currency_code: 'USD', optional: true),
-              Geckoboard::PercentageField.new(:completion, name: 'Completion', optional: true)
+              Geckoboard::DurationField.new(:span, name: 'Duration', time_unit: 'seconds', optional: true),
+              Geckoboard::PercentageField.new(:completion, name: 'Completion', optional: true),
+              Geckoboard::StringField.new(:company, name: 'Company', optional: true)
             ])
           end
         end


### PR DESCRIPTION
This PR adds support for the duration field type and for setting the string field type as optional.  

Currently, these capabilities are achieved by referencing [this public repo](https://github.com/megan-osiris/geckoboard-ruby-clone.git) in a project's Gemfile, but I'd like to transfer support to the primary geckoboard-ruby gem. 

Once merged, projects that might be referencing the alternate repo mentioned above (eg, hubspot-custom.., reamaze-custom.., bigcommerce-custom...) can be updated by changing the Gemfile line: 

gem 'geckoboard-ruby', git: 'https://github.com/megan-osiris/geckoboard-ruby-clone.git', branch: 'add-duration-field'

To: 

gem 'geckoboard-ruby'